### PR TITLE
feat: Smart Dedup v1 (#6)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,3 +3,4 @@ select=E,W,F
 exclude='.nox,*.egg,build,data'
 per-file-ignores=
     *.py:E501
+ignore=W503

--- a/src/iptv_spider/m3u.py
+++ b/src/iptv_spider/m3u.py
@@ -101,6 +101,11 @@ class M3U8:
             path=Path(cache_file) if cache_file else None
         )
         self.dedup_mode: str = dedup_mode
+        if dedup_keep not in ("first", "fastest"):
+            raise ValueError(
+                f"Invalid dedup_keep value: '{dedup_keep}'. "
+                "Must be 'first' or 'fastest'."
+            )
         self.dedup_keep: str = dedup_keep
         self.cache_enabled: bool = cache_enabled
         self.cache_ttl_hours: int = cache_ttl_hours

--- a/src/iptv_spider/m3u.py
+++ b/src/iptv_spider/m3u.py
@@ -59,6 +59,7 @@ class M3U8:
         "cache_ttl_hours",
         "cache_file",
         "cache_clear",
+        "dedup_trace",
     )
 
     def __init__(
@@ -105,10 +106,13 @@ class M3U8:
         self.cache_ttl_hours: int = cache_ttl_hours
         self.cache_file: Optional[str] = cache_file
         self.cache_clear: bool = cache_clear
+        self.dedup_trace: list[dict] = []
 
         if self.cache_clear:
             self.tested_channels = {}
-            self.__save_tested_channels(path=Path(self.cache_file) if self.cache_file else None)
+            self.__save_tested_channels(
+                path=Path(self.cache_file) if self.cache_file else None
+            )
 
         if self.dedup_mode == "url_fingerprint":
             self.__dedup_channels_by_fingerprint()
@@ -197,7 +201,9 @@ class M3U8:
         Returns:
             dict: Dictionary mapping URL fingerprints to test metadata.
         """
-        tested_channels_path = path if path else get_config_dir() / "tested_channels.json"
+        tested_channels_path = (
+            path if path else get_config_dir() / "tested_channels.json"
+        )
         try:
             if tested_channels_path.is_file():
                 with open(tested_channels_path, "r", encoding="utf-8") as f:
@@ -213,7 +219,9 @@ class M3U8:
         Args:
             path (Path): The file path to save the cache.
         """
-        tested_channels_path = path if path else get_config_dir() / "tested_channels.json"
+        tested_channels_path = (
+            path if path else get_config_dir() / "tested_channels.json"
+        )
         try:
             tested_channels_path.parent.mkdir(parents=True, exist_ok=True)
             with open(tested_channels_path, "w", encoding="utf-8") as f:
@@ -275,14 +283,39 @@ class M3U8:
                         best_speed[fp] = float(cached_speed)
                     continue
 
+                reason = "duplicate_url"
                 if self.dedup_keep == "fastest":
                     cached_speed = self.tested_channels.get(fp, {}).get("speed")
                     if cached_speed is None:
+                        self.dedup_trace.append(
+                            {
+                                "channel_name": channel.channel_name,
+                                "media_url": channel.media_url,
+                                "fingerprint": fp,
+                                "action": "skip",
+                                "reason": "no_cached_speed",
+                            }
+                        )
                         continue
                     cached_speed = float(cached_speed)
                     if fp not in best_speed or cached_speed > best_speed[fp]:
                         best_speed[fp] = cached_speed
                         seen[fp] = channel
+                        reason = "keep_faster"
+                    else:
+                        reason = "skip_slower"
+                else:
+                    reason = "skip_first_kept"
+
+                self.dedup_trace.append(
+                    {
+                        "channel_name": channel.channel_name,
+                        "media_url": channel.media_url,
+                        "fingerprint": fp,
+                        "action": "deduplicated",
+                        "reason": reason,
+                    }
+                )
             deduped[channel_name] = list(seen.values())
         self.channels = deduped
 
@@ -461,15 +494,22 @@ class M3U8:
                     last_tested = cached.get("last_tested")
                     if last_tested:
                         cached_time = self.__parse_cache_time(last_tested)
-                        if cached_time and now - cached_time <= timedelta(hours=self.cache_ttl_hours):
+                        if cached_time and now - cached_time <= timedelta(
+                            hours=self.cache_ttl_hours
+                        ):
                             channel.speed = cached.get("speed", channel.speed)
-                            channel.resolution = cached.get("resolution", channel.resolution)
+                            channel.resolution = cached.get(
+                                "resolution", channel.resolution
+                            )
                             channel.fps = float(cached.get("fps", channel.fps))
                             if channel_name not in best_channels:
                                 best_channels[channel_name] = channel
                             elif channel.speed > best_channels[channel_name].speed:
                                 best_channels[channel_name] = channel
-                            if server not in self.tested_servers or channel.speed > self.tested_servers[server]:
+                            if (
+                                server not in self.tested_servers
+                                or channel.speed > self.tested_servers[server]
+                            ):
                                 self.tested_servers[server] = channel.speed
                             continue
 
@@ -509,7 +549,10 @@ class M3U8:
                         best_channels[result_ch_name] = result_channel
 
                     # Update tested server speed
-                    if server not in self.tested_servers or speed > self.tested_servers[server]:
+                    if (
+                        server not in self.tested_servers
+                        or speed > self.tested_servers[server]
+                    ):
                         self.tested_servers[server] = speed
                     # Update tested channel cache
                     fingerprint = url_fingerprint(result_channel.media_url)
@@ -540,7 +583,9 @@ class M3U8:
         self.__save_black_servers()
         self.__save_tested_servers()
         if self.cache_enabled:
-            self.__save_tested_channels(path=Path(self.cache_file) if self.cache_file else None)
+            self.__save_tested_channels(
+                path=Path(self.cache_file) if self.cache_file else None
+            )
 
         logger.info(
             f"Testing completed. Best channels: {len(best_channels)}, Blacklisted servers: {len(self.black_servers)}"

--- a/src/iptv_spider/main.py
+++ b/src/iptv_spider/main.py
@@ -107,7 +107,9 @@ def main(
                 except Exception:
                     probe_metadata = None
             if isinstance(probe_metadata, dict):
-                metadata["resolution"] = probe_metadata.get("resolution", metadata["resolution"])
+                metadata["resolution"] = probe_metadata.get(
+                    "resolution", metadata["resolution"]
+                )
                 metadata["fps"] = _safe_fps(probe_metadata.get("fps"), metadata["fps"])
 
             best_channels[channel_name] = {
@@ -125,14 +127,16 @@ def main(
             }
 
     # Save filtered channels to a JSON file
-    json_filename = os.path.join(output_dir, f"best_channels_{datetime.today().strftime('%Y-%m-%d')}.json")
-    with open(json_filename, 'w', encoding='utf-8') as json_file:
+    json_filename = os.path.join(
+        output_dir, f"best_channels_{datetime.today().strftime('%Y-%m-%d')}.json"
+    )
+    with open(json_filename, "w", encoding="utf-8") as json_file:
         json.dump(best_channels, json_file, indent=4, ensure_ascii=False)
     logger.info(f"Filtered channel details saved to: {json_filename}")
 
     # Save results to an M3U file
-    m3u_filename = os.path.join(output_dir, 'best_channels.m3u')
-    with open(m3u_filename, 'w', encoding='utf-8') as m3u_file:
+    m3u_filename = os.path.join(output_dir, "best_channels.m3u")
+    with open(m3u_filename, "w", encoding="utf-8") as m3u_file:
         m3u_file.write(
             f'#EXTM3U url-tvg="{epg_url}"\n'
             if (output_with_epg and epg_url)
@@ -144,12 +148,15 @@ def main(
     logger.info(f"Filtered M3U playlist saved to: {m3u_filename}")
 
     # Calculate and return statistics
+    dedup_count = len(m3u8.dedup_trace) if hasattr(m3u8, "dedup_trace") else 0
     stats = {
         "total_channels_filtered": len(m3u8.channels),
         "best_channels_tested": len(best_channels_dict),
         "valid_channels_output": valid_channels,
         "speed_threshold_mb": speed_threshold_mb,
-        "output_files": [json_filename, m3u_filename]
+        "deduplicated_count": dedup_count,
+        "dedup_trace": m3u8.dedup_trace if hasattr(m3u8, "dedup_trace") else [],
+        "output_files": [json_filename, m3u_filename],
     }
 
     return stats
@@ -167,7 +174,9 @@ def entrypoint(argv: list[str] | None = None) -> None:
     logger.info("Runtime config: %s", sanitize_runtime_config(config))
     stats = main(
         m3u_url=str(config.get("url_or_path", "https://live.iptv365.org/live.m3u")),
-        regex_filter=str(config.get("filter", r"\b(cctv|CCTV)-?(?:[1-9]|1[0-7]|5\+?)\b")),
+        regex_filter=str(
+            config.get("filter", r"\b(cctv|CCTV)-?(?:[1-9]|1[0-7]|5\+?)\b")
+        ),
         output_dir=str(config.get("output_dir", ".")),
         speed_threshold_mb=config.get("speed_threshold_mb", 0.3),
         speed_limit_mb=config.get("speed_limit_mb", 2),

--- a/tests/test_iptv_spider.py
+++ b/tests/test_iptv_spider.py
@@ -450,7 +450,7 @@ class TestDedupKeepValidation(unittest.TestCase):
             temp_file = f.name
         try:
             with self.assertRaises(ValueError) as context:
-                M3U8(m3u_file=temp_file, dedup_keep="invalid")
+                M3U8(path=temp_file, regex_filter=".*", dedup_keep="invalid")
             self.assertIn("Invalid dedup_keep value", str(context.exception))
             self.assertIn("first", str(context.exception))
             self.assertIn("fastest", str(context.exception))

--- a/tests/test_iptv_spider.py
+++ b/tests/test_iptv_spider.py
@@ -157,6 +157,46 @@ http://example.com/cctv1.m3u8?a=1&b=2
             self.assertEqual(len(m3u8.channels["CCTV-1"]), 1)
         finally:
             import os
+
+            if os.path.exists(temp_m3u.name):
+                os.unlink(temp_m3u.name)
+
+    def test_m3u8_dedup_trace(self):
+        """Test that dedup_trace is populated with deduplication reasons."""
+        content = """#EXTM3U
+#EXTINF:-1 tvg-name="CCTV1",CCTV-1
+http://example.com/cctv1.m3u8
+#EXTINF:-1 tvg-name="CCTV1",CCTV-1
+http://example.com/cctv1.m3u8
+#EXTINF:-1 tvg-name="CCTV1",CCTV-1
+http://example.com/cctv1.m3u8?a=1&b=2
+#EXTINF:-1 tvg-name="CCTV2",CCTV-2
+http://example.com/cctv2.m3u8
+"""
+        temp_m3u = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".m3u", delete=False, encoding="utf-8"
+        )
+        temp_m3u.write(content)
+        temp_m3u.close()
+        try:
+            m3u8 = M3U8(
+                path=temp_m3u.name,
+                regex_filter=r".*",
+                max_retries=1,
+                request_timeout=10,
+                dedup_mode="url_fingerprint",
+            )
+            self.assertIsInstance(m3u8.dedup_trace, list)
+            self.assertGreater(len(m3u8.dedup_trace), 0)
+            for entry in m3u8.dedup_trace:
+                self.assertIn("channel_name", entry)
+                self.assertIn("media_url", entry)
+                self.assertIn("fingerprint", entry)
+                self.assertIn("action", entry)
+                self.assertIn("reason", entry)
+        finally:
+            import os
+
             if os.path.exists(temp_m3u.name):
                 os.unlink(temp_m3u.name)
 
@@ -195,13 +235,16 @@ http://example.com/cctv1.m3u8
                     cache_ttl_hours=24,
                     cache_file=str(cache_file),
                 )
-                with patch("src.iptv_spider.channel.Channel.get_speed") as mock_get_speed:
+                with patch(
+                    "src.iptv_spider.channel.Channel.get_speed"
+                ) as mock_get_speed:
                     best = m3u8.get_best_channels()
                     mock_get_speed.assert_not_called()
                 self.assertIn("CCTV-1", best)
                 self.assertEqual(best["CCTV-1"].speed, 123456.0)
             finally:
                 import os
+
                 if os.path.exists(temp_m3u.name):
                     os.unlink(temp_m3u.name)
 
@@ -220,7 +263,9 @@ http://example.com/cctv1.m3u8
             cache_file = Path(tmpdir) / "tested_channels.json"
             fp = url_fingerprint("http://example.com/cctv1.m3u8")
             with open(cache_file, "w", encoding="utf-8") as f:
-                json.dump({fp: {"speed": 1, "last_tested": "2099-01-01T00:00:00+00:00"}}, f)
+                json.dump(
+                    {fp: {"speed": 1, "last_tested": "2099-01-01T00:00:00+00:00"}}, f
+                )
             try:
                 m3u8 = M3U8(
                     path=temp_m3u.name,
@@ -237,6 +282,7 @@ http://example.com/cctv1.m3u8
                 self.assertEqual(saved, {})
             finally:
                 import os
+
                 if os.path.exists(temp_m3u.name):
                     os.unlink(temp_m3u.name)
 
@@ -328,6 +374,7 @@ http://example.com/cctv2.m3u8
         mock_instance = MagicMock()
         mock_instance.channels = {"CCTV-1": [], "CCTV-2": []}
         mock_instance.get_best_channels.return_value = {}
+        mock_instance.dedup_trace = []
         mock_m3u8.return_value = mock_instance
 
         stats = main(
@@ -345,6 +392,8 @@ http://example.com/cctv2.m3u8
         self.assertIn("best_channels_tested", stats)
         self.assertIn("valid_channels_output", stats)
         self.assertIn("speed_threshold_mb", stats)
+        self.assertIn("deduplicated_count", stats)
+        self.assertIn("dedup_trace", stats)
         self.assertIn("output_files", stats)
 
     @patch("src.iptv_spider.main.M3U8")
@@ -353,7 +402,7 @@ http://example.com/cctv2.m3u8
         mock_instance = MagicMock()
         channel = MagicMock()
         channel.channel_name = "CCTV-1"
-        channel.meta = "#EXTINF:-1 tvg-name=\"CCTV1\""
+        channel.meta = '#EXTINF:-1 tvg-name="CCTV1"'
         channel.media_url = "http://example.com/cctv1.m3u8"
         channel.speed = 1000000
         channel.resolution = "1920x1080"
@@ -380,6 +429,7 @@ http://example.com/cctv2.m3u8
             self.assertEqual(first_line, '#EXTM3U url-tvg="http://example.com/epg.xml"')
         finally:
             import shutil
+
             if Path(output_dir).exists():
                 shutil.rmtree(output_dir)
 

--- a/tests/test_iptv_spider.py
+++ b/tests/test_iptv_spider.py
@@ -436,3 +436,23 @@ http://example.com/cctv2.m3u8
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestDedupKeepValidation(unittest.TestCase):
+    """Test cases for dedup_keep parameter validation."""
+
+    def test_invalid_dedup_keep_raises_error(self):
+        """Test that invalid dedup_keep value raises ValueError."""
+        from src.iptv_spider.m3u import M3U8
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".m3u", delete=False) as f:
+            f.write("#EXTM3U\n#EXTINF:-1,Test\nhttp://example.com/test.m3u\n")
+            temp_file = f.name
+        try:
+            with self.assertRaises(ValueError) as context:
+                M3U8(m3u_file=temp_file, dedup_keep="invalid")
+            self.assertIn("Invalid dedup_keep value", str(context.exception))
+            self.assertIn("first", str(context.exception))
+            self.assertIn("fastest", str(context.exception))
+        finally:
+            Path(temp_file).unlink()


### PR DESCRIPTION
## Summary
Implements Issue #6: Smart deduplication v1

## Changes
- URL normalization (lowercase scheme/host, remove fragment, sort query)
- URL fingerprint (SHA1 hash)
- dedup_trace for tracking dedup reason
- dedup_keep policy (first/fastest)

## Acceptance Criteria
- [x] Dedup results include trace logs/reason fields
- [x] Duplicate ratio decreases on sample datasets
- [x] No regressions on existing dedup behavior tests

## Testing
`ash
nox -s lint
nox -s tests
`

Fixes #6