### PR TITLE
fix: Add use_github_token to opencode workflows

### DIFF
--- a/.github/workflows/opencode-comment.yml
+++ b/.github/workflows/opencode-comment.yml
@@ -30,3 +30,4 @@ jobs:
           OPENCODE_ZEN_API_KEY: ${{ secrets.OPENCODE_ZEN_API_KEY }}
         with:
           model: opencode/minimax-m2.5-free
+          use_github_token: true

--- a/.github/workflows/opencode-issue.yml
+++ b/.github/workflows/opencode-issue.yml
@@ -24,6 +24,7 @@ jobs:
           OPENCODE_ZEN_API_KEY: ${{ secrets.OPENCODE_ZEN_API_KEY }}
         with:
           model: opencode/minimax-m2.5-free
+          use_github_token: true
           prompt: |
             Analyze this issue and provide implementation guidance:
             

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -25,6 +25,7 @@ jobs:
           OPENCODE_ZEN_API_KEY: ${{ secrets.OPENCODE_ZEN_API_KEY }}
         with:
           model: opencode/minimax-m2.5-free
+          use_github_token: true
           prompt: |
             Review this pull request systematically:
             


### PR DESCRIPTION
## Summary
Fixes the OpenCode bot permission issue where it was failing with:
User opencode-agent[bot] does not have write permissions

## Root Cause
When GitHub Actions runs as a GitHub App (like opencode-agent), the GitHub API
always returns permission: none for bot actors because their permissions
come from the App installation, not the collaborators model.

This is a known issue in opencode: https://github.com/anomalyco/opencode/issues/17224

## Fix
Add use_github_token: true to all opencode workflow files:
- .github/workflows/opencode-review.yml
- .github/workflows/opencode-comment.yml
- .github/workflows/opencode-issue.yml

This tells opencode to skip the permission check since the workflow is already
managing its own authentication via GITHUB_TOKEN.