### PR TITLE
feat: Add API sync exporter (#8)

### DIFF
--- a/src/iptv_spider/api_client.py
+++ b/src/iptv_spider/api_client.py
@@ -30,6 +30,8 @@ class APIClient:
         max_retries: int = 3,
         timeout: int = 30,
     ):
+        if not endpoint.startswith(("http://", "https://")):
+            raise ValueError("endpoint must start with http:// or https://")
         self.endpoint = endpoint
         self.token = token
         self.max_retries = max_retries

--- a/src/iptv_spider/api_client.py
+++ b/src/iptv_spider/api_client.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+"""
+HTTP client for API sync with retry and backoff support.
+"""
+
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import requests
+
+
+@dataclass
+class SyncResult:
+    """Result of an API sync operation."""
+
+    success: bool
+    status_code: int | None
+    error_message: str | None
+    retry_count: int
+
+
+class APIClient:
+    """HTTP client with retry and backoff."""
+
+    def __init__(
+        self,
+        endpoint: str,
+        token: str | None = None,
+        max_retries: int = 3,
+        timeout: int = 30,
+    ):
+        self.endpoint = endpoint
+        self.token = token
+        self.max_retries = max_retries
+        self.timeout = timeout
+        self.headers: dict[str, str] = {"Content-Type": "application/json"}
+        if token:
+            self.headers["Authorization"] = f"Bearer {token}"
+
+    def post(self, payload: dict[str, Any]) -> SyncResult:
+        """POST payload to endpoint with retry."""
+        last_error = None
+
+        for attempt in range(self.max_retries):
+            try:
+                response = requests.post(
+                    self.endpoint,
+                    json=payload,
+                    headers=self.headers,
+                    timeout=self.timeout,
+                )
+                if response.status_code < 400:
+                    return SyncResult(
+                        success=True,
+                        status_code=response.status_code,
+                        error_message=None,
+                        retry_count=attempt,
+                    )
+                last_error = f"HTTP {response.status_code}: {response.text}"
+            except requests.RequestException as e:
+                last_error = str(e)
+
+            if attempt < self.max_retries - 1:
+                wait_time = 2**attempt
+                time.sleep(wait_time)
+
+        return SyncResult(
+            success=False,
+            status_code=None,
+            error_message=last_error,
+            retry_count=self.max_retries - 1,
+        )

--- a/src/iptv_spider/api_client.py
+++ b/src/iptv_spider/api_client.py
@@ -50,7 +50,7 @@ class APIClient:
                     headers=self.headers,
                     timeout=self.timeout,
                 )
-                if response.status_code < 400:
+                if response.ok:
                     return SyncResult(
                         success=True,
                         status_code=response.status_code,

--- a/src/iptv_spider/sync_exporter.py
+++ b/src/iptv_spider/sync_exporter.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+"""
+Sync exporter for pushing results to external API.
+"""
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from iptv_spider.api_client import APIClient
+
+
+@dataclass
+class SyncError:
+    """Represents a sync error."""
+
+    field: str
+    message: str
+
+
+class SyncExporter:
+    """Exports channels to external API with local backup."""
+
+    def __init__(
+        self,
+        endpoint: str,
+        token: str | None = None,
+        max_retries: int = 3,
+        timeout: int = 30,
+        backup_dir: str = "backups",
+    ):
+        self.client = APIClient(endpoint, token, max_retries, timeout)
+        self.backup_dir = backup_dir
+        self._ensure_backup_dir()
+
+    def _ensure_backup_dir(self) -> None:
+        """Create backup directory if needed."""
+        Path(self.backup_dir).mkdir(parents=True, exist_ok=True)
+
+    def sync_and_backup(
+        self, channels: dict[str, Any], filename: str
+    ) -> list[SyncError]:
+        """Sync to API, fallback to local backup on failure."""
+        errors: list[SyncError] = []
+
+        payload = {
+            "channels": channels,
+            "timestamp": str(Path(filename).stem),
+        }
+
+        result = self.client.post(payload)
+
+        if result.success:
+            return errors
+
+        errors.append(
+            SyncError(
+                field="api_sync",
+                message=f"Sync failed: {result.error_message}",
+            )
+        )
+
+        backup_path = self._create_backup(channels, filename)
+        if backup_path:
+            errors.append(
+                SyncError(
+                    field="backup",
+                    message=f"Created backup at: {backup_path}",
+                )
+            )
+
+        return errors
+
+    def _create_backup(self, channels: dict[str, Any], filename: str) -> str | None:
+        """Create local backup file."""
+        try:
+            backup_filename = f"{filename}.backup.json"
+            backup_path = Path(self.backup_dir) / backup_filename
+            with open(backup_path, "w", encoding="utf-8") as f:
+                json.dump(channels, f, indent=2, ensure_ascii=False)
+            return str(backup_path)
+        except OSError:
+            return None
+
+
+def create_sync_exporter(
+    endpoint: str,
+    token: str | None = None,
+    max_retries: int = 3,
+    timeout: int = 30,
+    backup_dir: str = "backups",
+) -> SyncExporter:
+    """Factory function to create SyncExporter."""
+    return SyncExporter(
+        endpoint=endpoint,
+        token=token,
+        max_retries=max_retries,
+        timeout=timeout,
+        backup_dir=backup_dir,
+    )

--- a/tests/test_sync_exporter.py
+++ b/tests/test_sync_exporter.py
@@ -33,6 +33,17 @@ class TestAPIClient(unittest.TestCase):
         self.assertIsNone(client.token)
         self.assertNotIn("Authorization", client.headers)
 
+    def test_invalid_endpoint_protocol(self):
+        """Test invalid endpoint protocol raises ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            APIClient(endpoint="file:///etc/passwd")
+        self.assertIn("http:// or https://", str(ctx.exception))
+
+    def test_https_endpoint(self):
+        """Test HTTPS endpoint is accepted."""
+        client = APIClient(endpoint="https://example.com/api")
+        self.assertEqual(client.endpoint, "https://example.com/api")
+
 
 class TestSyncExporter(unittest.TestCase):
     """Test sync exporter."""
@@ -114,18 +125,6 @@ class TestSyncExporter(unittest.TestCase):
         errors = exporter.sync_and_backup(channels, f"test_{id(self)}.json")
 
         self.assertEqual(len(errors), 0)
-
-
-class TestSyncExporterWithMock(unittest.TestCase):
-    """Test sync exporter with mock server."""
-
-    def setUp(self):
-        self.temp_dir = tempfile.mkdtemp()
-
-    def tearDown(self):
-        import shutil
-
-        shutil.rmtree(self.temp_dir, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_sync_exporter.py
+++ b/tests/test_sync_exporter.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+"""Tests for API sync exporter."""
+
+import json
+import unittest
+from pathlib import Path
+import tempfile
+
+from iptv_spider.sync_exporter import SyncError, create_sync_exporter
+from iptv_spider.api_client import APIClient
+
+
+class TestAPIClient(unittest.TestCase):
+    """Test API client."""
+
+    def test_client_initialization(self):
+        """Test client is initialized with correct values."""
+        client = APIClient(
+            endpoint="http://example.com/api",
+            token="secret",
+            max_retries=3,
+            timeout=30,
+        )
+        self.assertEqual(client.endpoint, "http://example.com/api")
+        self.assertEqual(client.token, "secret")
+        self.assertEqual(client.max_retries, 3)
+        self.assertEqual(client.timeout, 30)
+        self.assertIn("Authorization", client.headers)
+
+    def test_client_no_token(self):
+        """Test client without token."""
+        client = APIClient(endpoint="http://example.com/api")
+        self.assertIsNone(client.token)
+        self.assertNotIn("Authorization", client.headers)
+
+
+class TestSyncExporter(unittest.TestCase):
+    """Test sync exporter."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_exporter_creation(self):
+        """Test exporter is created with correct values."""
+        exporter = create_sync_exporter(
+            endpoint="http://example.com/api",
+            token="secret",
+            backup_dir=self.temp_dir,
+        )
+        self.assertEqual(exporter.client.endpoint, "http://example.com/api")
+        self.assertEqual(exporter.backup_dir, self.temp_dir)
+
+    def test_backup_directory_created(self):
+        """Test backup directory is created."""
+        backup_dir = Path(self.temp_dir) / "backups"
+        create_sync_exporter(
+            endpoint="http://example.com/api",
+            backup_dir=str(backup_dir),
+        )
+        self.assertTrue(backup_dir.exists())
+        self.assertTrue(backup_dir.is_dir())
+
+    def test_sync_error_dataclass(self):
+        """Test SyncError structure."""
+        error = SyncError(field="test", message="test message")
+        self.assertEqual(error.field, "test")
+        self.assertEqual(error.message, "test message")
+
+    def test_create_backup(self):
+        """Test local backup creation."""
+        exporter = create_sync_exporter(
+            endpoint="http://example.com/api",
+            backup_dir=self.temp_dir,
+        )
+        channels = {"Channel1": {"url": "http://example.com"}}
+        backup_path = exporter._create_backup(channels, "test_channels.json")
+
+        self.assertIsNotNone(backup_path)
+        self.assertTrue(Path(backup_path).exists())
+
+        with open(backup_path) as f:
+            saved = json.load(f)
+        self.assertEqual(saved, channels)
+
+    def test_sync_and_backup_failure(self):
+        """Test sync then backup on failure."""
+        exporter = create_sync_exporter(
+            endpoint="http://127.0.0.1:1/api",
+            backup_dir=self.temp_dir,
+            max_retries=1,
+            timeout=2,
+        )
+        channels = {"Channel1": {"url": "http://example.com"}}
+
+        errors = exporter.sync_and_backup(channels, "test.json")
+
+        self.assertEqual(len(errors), 2)
+        self.assertEqual(errors[0].field, "api_sync")
+        self.assertEqual(errors[1].field, "backup")
+
+    def test_sync_and_backup_success(self):
+        """Test sync succeeds (no backup needed)."""
+        exporter = create_sync_exporter(
+            endpoint="http://httpbin.org/post",
+            backup_dir=self.temp_dir,
+        )
+        channels = {"TestChannel": {"url": "http://test.com"}}
+
+        errors = exporter.sync_and_backup(channels, f"test_{id(self)}.json")
+
+        self.assertEqual(len(errors), 0)
+
+
+class TestSyncExporterWithMock(unittest.TestCase):
+    """Test sync exporter with mock server."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements Issue #8

- Add APIClient with retry/retry backoff
- Add SyncExporter with local backup
- Add create_sync_exporter factory

Fixes #8